### PR TITLE
Add library.properties metadata file

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,10 @@
+name=Dynamic DNS
+version=0.1
+author=Eliza Weisman
+maintainer=Eliza Weisman
+sentence=Dynamic DNS library.
+paragraph=Update dynamic DNS services using a W5100 or W5500 Ethernet controller.
+category=Communication
+url=https://github.com/hawkw/arduino_dynamic_dns
+architectures=*
+includes=DynamicDNS.h


### PR DESCRIPTION
Libraries in the Arduino Library 1.5 format (source files under the src subfolder) are required to have a library.properties file in the root folder. If this file is not present the library is not recognized by the Arduino IDE.

This file is also required for inclusion in the Arduino Library Manager index.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#library-metadata